### PR TITLE
update - tile version 1.1.4

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -53,7 +53,7 @@ The following table provides version and version-support information about New R
     </tr>
     <tr>
         <td>Release date</td>
-        <td>Jan 6, 2020</td>
+        <td>Jan 14, 2020</td>
     </tr>
     <tr>
         <td>Software component version</td>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -49,27 +49,27 @@ The following table provides version and version-support information about New R
     <th>Details</th>
     <tr>
         <td>Tile version</td>
-        <td>1.1.3</td>
+        <td>1.1.4</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>Dec 13, 2019</td>
+        <td>Jan 6, 2020</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>New Relic Dotnet Extension Buildpack 1.1.3</td>
+        <td>New Relic Dotnet Extension Buildpack 1.1.4</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>2.5, 2.6, and 2.7</td>
+        <td>2.5, 2.6, 2.7, and 2.8</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service versions</td>
-        <td>2.5, 2.6, and 2.7</td>
+        <td>2.5, 2.6, 2.7, and 2.8</td>
     </tr>
     <tr>
         <td>BOSH stemcell version</td>
-        <td>Ubuntu Xenial</td>
+        <td>Ubuntu Xenial 315</td>
     </tr>
     <tr>
         <td>IaaS support</td>
@@ -79,7 +79,7 @@ The following table provides version and version-support information about New R
 
 ## <a id='compatibility'></a> Compatibility
 
-This product has been tested and is compatible with Pivotal Platform versions up to and including v2.7.
+This product has been tested and is compatible with Pivotal Platform versions up to and including v2.8.
 
 
 ## <a id="reqs"></a> Requirements

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -8,7 +8,7 @@ These are release notes for New Relic Dotnet Extension Buildpack for Pivotal Pla
 
 ## <a id="ver-1.1.4"></a> v1.1.4 
 
-**General Access Release Date:** January 6, 2020
+**General Access Release Date:** January 14, 2020
 
 Features included in this release:
 

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -6,6 +6,17 @@ owner: Partners
 These are release notes for New Relic Dotnet Extension Buildpack for Pivotal Platform.
 
 
+## <a id="ver-1.1.4"></a> v1.1.4 
+
+**General Access Release Date:** January 6, 2020
+
+Features included in this release:
+
+* Support for custom instrumentation XML files for Dotnet Framework extension
+* Support for `"NEW_RELIC_AGENT_VERSION"` environment variable in Dotnet Core extension
+* Tested with Pivotal Platform versions up to and including 2.8
+
+
 ## <a id="ver-1.1.3"></a> v1.1.3 
 
 **General Access Release Date:** December 13, 2019

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -14,13 +14,14 @@ to make it easy and convenient to bind apps to a New Relic service.
 ### <a id='how-it-works'></a> How the New Relic Extension Buildpack for Pivotal Platform Works
 
 The buildpack extensions bind to the New Relic Dotnet agent using one of the following ways depending on the environment:
-
-1. If an environment variable named `NEW_RELIC_DOWNLOAD_URL` is defined in the app environment
+1. If an environment variable named `"NEW_RELIC_DOWNLOAD_URL"` is defined in the app environment
 (manifest file, cf set-env, or set in Apps Manager), its value is used as the location to download the agent.
 This is used for environments where you have your own repository for downloading dependencies (i.e. Artifactory).
-If a second environment variable called `NEW_RELIC_DOWNLOAD_SHA256` is set in the app environment,
+If a second environment variable called `"NEW_RELIC_DOWNLOAD_SHA256"` is set in the app environment,
 it is expected to hold the downloaded agent's binary file SHA256 checksum.
 In this case the SHA256 checksum of the downloaded agent binary file is compared with this value, and in the case of a mismatch, the buildpack reports an error.
+
+1. If you want the buildpack to use a specific version of New Relic agent, you could define an environment variable `"NEW_RELIC_AGENT_VERSION"` with the desired agent version. Please note that if you use both `"NEW_RELIC_DOWNLOAD_URL"` and `"NEW_RELIC_AGENT_VERSION"` together, the version number will be ignored, and only the url will be used.
 
 1. You can create a cached version of the buildpack using the `--cached` switch with New Relic agent embedded in
 the buildpack. This is mainly used in disconnected (isolated) environments where Pivotal Platform does not have access to the


### PR DESCRIPTION
release 1.1.4

- Support for custom instrumentation XML files for Dotnet Framework extension
- Support for "NEW_RELIC_AGENT_VERSION" environment variable in Dotnet Core extension
- Tested with Pivotal Platform versions up to and including 2.8
