### PR TITLE
update docs for buildpack version 1.1.5

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -37,7 +37,7 @@ following buildpacks depending on the tile configuration (total of 8 extension b
 All buildpacks use the multi-buildpack approach of Cloud Foundry and require either the standard 
 Dotnet Core buildpack or HWC buildpack to be specified as the last buildpack in the buildpack chain, either in the app manifest or in the <code>cf push</code> command line.
 
-<p class="note"><strong>Note:</strong> The cached version of this extension buildpack for both Dotnet Core and Dotnet Framework contains New Relic Dotnet Agents version <code>8.21.34.0</code></p>
+<p class="note"><strong>Note:</strong> The cached version of this extension buildpack for both Dotnet Core and Dotnet Framework contains New Relic Dotnet Agents version <code>8.27.139.0</code></p>
 
 
 ## <a id="snapshot"></a> Product Snapshot
@@ -49,27 +49,27 @@ The following table provides version and version-support information about New R
     <th>Details</th>
     <tr>
         <td>Tile version</td>
-        <td>1.1.4</td>
+        <td>1.1.5</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>Jan 14, 2020</td>
+        <td>May 14, 2020</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>New Relic Dotnet Extension Buildpack 1.1.4</td>
+        <td>New Relic Dotnet Extension Buildpack 1.1.5</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>2.5, 2.6, 2.7, and 2.8</td>
+        <td>2.6, 2.7, 2.8, and 2.9</td>
     </tr>
     <tr>
         <td>Compatible VMware Tanzu Application Service for VMs versions</td>
-        <td>2.5, 2.6, 2.7, and 2.8</td>
+        <td>2.6, 2.7, 2.8, and 2.9</td>
     </tr>
     <tr>
         <td>BOSH stemcell version</td>
-        <td>Ubuntu Xenial 315</td>
+        <td>Ubuntu Xenial</td>
     </tr>
     <tr>
         <td>IaaS support</td>
@@ -79,7 +79,7 @@ The following table provides version and version-support information about New R
 
 ## <a id='compatibility'></a> Compatibility
 
-This product has been tested and is compatible with VMware Tanzu versions up to and including v2.8.
+This product has been tested and is compatible with VMware Tanzu versions up to and including v2.9.
 
 
 ## <a id="reqs"></a> Requirements

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -6,6 +6,16 @@ owner: Partners
 These are release notes for New Relic Dotnet Extension Buildpack for VMware Tanzu.
 
 
+## <a id="ver-1.1.5"></a> v1.1.5 
+
+**General Access Release Date:** May 14, 2020
+
+Features included in this release:
+
+* Upgraded tile metadata to 2.0
+* Tested with VMware Tanzu versions up to and including 2.9
+
+
 ## <a id="ver-1.1.4"></a> v1.1.4 
 
 **General Access Release Date:** January 14, 2020


### PR DESCRIPTION
- Upgraded tile metadata to 2.0
- Tested with VMware Tanzu versions up to and including 2.9
