### PR TITLE
buildpack 1.1.6 - support for TAS 2.10

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -37,7 +37,7 @@ following buildpacks depending on the tile configuration (total of 8 extension b
 All buildpacks use the multi-buildpack approach of Cloud Foundry and require either the standard 
 Dotnet Core buildpack or HWC buildpack to be specified as the last buildpack in the buildpack chain, either in the app manifest or in the <code>cf push</code> command line.
 
-<p class="note"><strong>Note:</strong> The cached version of this extension buildpack for both Dotnet Core and Dotnet Framework contains New Relic Dotnet Agents version <code>8.27.139.0</code></p>
+<p class="note"><strong>Note:</strong> The cached version of this extension buildpack for both Dotnet Core and Dotnet Framework contains New Relic Dotnet Agents version <code>8.31.0</code></p>
 
 
 ## <a id="snapshot"></a> Product Snapshot
@@ -49,23 +49,23 @@ The following table provides version and version-support information about New R
     <th>Details</th>
     <tr>
         <td>Tile version</td>
-        <td>1.1.5</td>
+        <td>1.1.6</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>May 15, 2020</td>
+        <td>September 5, 2020</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>New Relic Dotnet Extension Buildpack 1.1.5</td>
+        <td>New Relic Dotnet Extension Buildpack 1.1.6</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>2.6, 2.7, 2.8, and 2.9</td>
+        <td>2.6, 2.7, 2.8, 2.9, and 2.10</td>
     </tr>
     <tr>
         <td>Compatible VMware Tanzu Application Service for VMs versions</td>
-        <td>2.6, 2.7, 2.8, and 2.9</td>
+        <td>2.6, 2.7, 2.8, 2.9, and 2.10</td>
     </tr>
     <tr>
         <td>BOSH stemcell version</td>
@@ -79,7 +79,7 @@ The following table provides version and version-support information about New R
 
 ## <a id='compatibility'></a> Compatibility
 
-This product has been tested and is compatible with VMware Tanzu versions up to and including v2.9.
+This product has been tested and is compatible with VMware Tanzu versions up to and including v2.10.
 
 
 ## <a id="reqs"></a> Requirements

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -53,7 +53,7 @@ The following table provides version and version-support information about New R
     </tr>
     <tr>
         <td>Release date</td>
-        <td>September 5, 2020</td>
+        <td>September 8, 2020</td>
     </tr>
     <tr>
         <td>Software component version</td>

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -6,6 +6,19 @@ owner: Partners
 These are release notes for New Relic Dotnet Extension Buildpack for VMware Tanzu.
 
 
+## <a id="ver-1.1.6"></a> v1.1.6 
+
+**General Access Release Date:** September 5, 2020
+
+Features included in this release:
+
+* Support for TAS 2.10
+* Improved the process for obtaining New Relic's agent
+* Tested Dotnet Core on xenial stemcells with VMware Tanzu versions up to and including 2.10
+* Tested Dotnet Framework (Classic) on Windows 2019 stemcells with VMware Tanzu versions up to and including 2.10
+* Tested Dotnet Framework (Classic) on Windows 2016 stemcells with VMware Tanzu versions up to and including 2.9
+
+
 ## <a id="ver-1.1.5"></a> v1.1.5 
 
 **General Access Release Date:** May 15, 2020

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -8,7 +8,7 @@ These are release notes for New Relic Dotnet Extension Buildpack for VMware Tanz
 
 ## <a id="ver-1.1.6"></a> v1.1.6 
 
-**General Access Release Date:** September 5, 2020
+**General Access Release Date:** September 8, 2020
 
 Features included in this release:
 


### PR DESCRIPTION
* Support for TAS 2.10
* Improved the process for obtaining New Relic's agent
* Tested Dotnet Core on xenial stemcells with VMware Tanzu versions up to and including 2.10
* Tested Dotnet Framework (Classic) on Windows 2019 stemcells with VMware Tanzu versions up to and including 2.10
* Tested Dotnet Framework (Classic) on Windows 2016 stemcells with VMware Tanzu versions up to and including 2.9
