### PR TITLE
update docs for v1.1.7

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -49,23 +49,23 @@ The following table provides version and version-support information about New R
     <th>Details</th>
     <tr>
         <td>Tile version</td>
-        <td>1.1.6</td>
+        <td>1.1.7</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>September 8, 2020</td>
+        <td>March 15, 2021</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>New Relic Dotnet Extension Buildpack 1.1.6</td>
+        <td>New Relic Dotnet Extension Buildpack 1.1.7</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>2.6, 2.7, 2.8, 2.9, and 2.10</td>
+        <td>2.8, 2.9, 2.10, and 2.11</td>
     </tr>
     <tr>
         <td>Compatible VMware Tanzu Application Service for VMs versions</td>
-        <td>2.6, 2.7, 2.8, 2.9, and 2.10</td>
+        <td>2.8, 2.9, 2.10, and 2.11</td>
     </tr>
     <tr>
         <td>BOSH stemcell version</td>

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -6,6 +6,19 @@ owner: Partners
 These are release notes for New Relic Dotnet Extension Buildpack for VMware Tanzu.
 
 
+## <a id="ver-1.1.7"></a> v1.1.7
+
+**General Access Release Date:** March 15, 2021
+
+Features included in this release:
+
+* Support for TAS 2.11
+* Support for .NET 5.0
+* Extended support for passing any environment variables via user-provided-service
+* Tested Dotnet Core on xenial stemcells with VMware Tanzu versions up to and including 2.11
+* Tested Dotnet Framework (Classic) on Windows 2019 stemcells with VMware Tanzu versions up to and including 2.11
+
+
 ## <a id="ver-1.1.6"></a> v1.1.6 
 
 **General Access Release Date:** September 8, 2020

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -93,13 +93,15 @@ You can make a copy of this file in the app root directory, and change any of th
 
 ### <a id='ups'></a> New Relic User-Provided Service
 
-If the app binds to a user provided service with the word `newrelic` as part of its name, the buildpack injects the credentials from this service in the app environment by setting environment variables for known New Relic properties. The known properties currently are:
+If the app binds to a user provided service with the word `newrelic` as part of its name, the buildpack injects the credentials from this service in the app environment by setting these credentials as environment variables before starting the app.
 
-* `NEW_RELIC_LICNESE_KEY`
+* If the credential starts with prefix "new\_relic\_", the buildpack ensures the environment variable name is all in upper case.
 
-* `NEW_RELIC_APP_NAME`
+* Certain credentials without "NEW\_RELIC\_" prefix qualify as New Relic environment variables and are translated by the buildpack:
 
-* `NEW_RELIC_DISTRIBUTED_TRACING_ENABLED`
+	+ upper or lower case license\_key, licensekey would translate to "NEW\_RELIC\_LICENSE\_KEY"
+	+ upper or lower case app\_name, appname would translate to "NEW\_RELIC\_APP\_NAME"
+	+ upper or lower case distributed\_tracing, distributedtracing would translate to "NEW_RELIC\_DISTRIBUTED\_TRACING\_ENABLED"
 
 
 ### <a id='proxy'></a> Use of Proxy
@@ -402,6 +404,13 @@ applications:
   </pre>
 
 1. To push the app to VMware Tanzu, run the `cf push` command.
+
+1. To [pin the .NET Core SDK to a specific version or version line](https://docs.cloudfoundry.org/buildpacks/dotnet-core/index.html#-specify-.net-core-sdks), create a buildpack.yml file at the app root and add your SDK version:
+
+	```
+ 	dotnet-core:
+		sdk: 5.x
+	```
 
 
 ### <a id='example-dotnet-framework'></a>Push a Sample Dotnet Framework App to VMware Tanzu


### PR DESCRIPTION
* Support for TAS 2.11
* Support for .NET 5.0
* Extended support for passing any environment variables via user-provided-service
* Tested Dotnet Core on xenial stemcells with VMware Tanzu versions up to and including 2.11
* Tested Dotnet Framework (Classic) on Windows 2019 stemcells with VMware Tanzu versions up to and including 2.11
